### PR TITLE
Image processing

### DIFF
--- a/api/items-images/items-images-model.js
+++ b/api/items-images/items-images-model.js
@@ -79,8 +79,8 @@ async function addMainImage(item_id, image_info) {
       await resizedUpload.uploadResizedImages(
         item_id,
         file_name,
-        body,
-        content_type
+        body
+        // content_type
       );
     // add info to the db
     const result = await addMainImageSizes(

--- a/api/items-images/items-images-router.js
+++ b/api/items-images/items-images-router.js
@@ -59,8 +59,8 @@ router.post(
       await resizedUpload.uploadResizedImages(
         item_id,
         file_name,
-        body,
-        content_type
+        body
+        // content_type
       );
     // save the urls to the db
     Images.addMainImageSizes(

--- a/api/utils/imageUploader.js
+++ b/api/utils/imageUploader.js
@@ -175,7 +175,7 @@ class ResizedMainImageUploader extends ImageUploader {
             width = metadata.width;
             height = metadata.height;
           }
-          const quality = name.includes('tiny') ? 25 : 100;
+          const quality = name.includes('tiny') ? 5 : 100;
           const fitType =
             name.includes('display') || name.includes('main')
               ? 'cover'

--- a/api/utils/imageUploader.js
+++ b/api/utils/imageUploader.js
@@ -158,7 +158,7 @@ class ResizedMainImageUploader extends ImageUploader {
   }
 
   //method to upload resized images (resized with Sharp)
-  async uploadResizedImages(id, file_name, body, content_type) {
+  async uploadResizedImages(id, file_name, body) {
     const Bucket = process.env.S3_BUCKET_NAME;
     let baseUrl;
     let ratio;
@@ -202,7 +202,7 @@ class ResizedMainImageUploader extends ImageUploader {
             Bucket,
             Body: sizedBody,
             Key: `${this.dir(id)}/${name}_${file_name}`,
-            ContentType: content_type,
+            ContentType: 'image/webp',
             ACL: 'public-read'
           });
           await this.s3.send(command);

--- a/api/utils/imageUploader.js
+++ b/api/utils/imageUploader.js
@@ -175,7 +175,7 @@ class ResizedMainImageUploader extends ImageUploader {
             width = metadata.width;
             height = metadata.height;
           }
-          const quality = name.includes('tiny') ? 15 : 100;
+          const quality = name.includes('tiny') ? 25 : 100;
           const fitType =
             name.includes('display') || name.includes('main')
               ? 'cover'
@@ -191,7 +191,7 @@ class ResizedMainImageUploader extends ImageUploader {
               fit: fitType,
               background: { r: 255, g: 255, b: 255, alpha: 1 }
             })
-            .jpeg({
+            .toFormat('webp', {
               quality: quality,
               trellisQuantisation: true,
               overshootDeringing: true


### PR DESCRIPTION
Convert all resized images to webp format and reduce quality of placeholders 
- note: webp looks better even with reduced quality for all 20 tested images
- also the file size for the 25% quality webp is larger than the 25% jpeg
- this may be because the jpegs were already optimized and most I use will be
- however, generally the 100% quality webp is smaller or equal in size to the jpeg
